### PR TITLE
Fix block column in empty partitions, force uint23.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="subgraph_extractor",
-    version="0.1.0",
+    version="0.1.1",
     description="Pull data from graph-node databases into parquet files",
     url="http://github.com/cardstack/subgraph-extractor",
     author="Ian Calvert",

--- a/subgraph_extractor/cli.py
+++ b/subgraph_extractor/cli.py
@@ -15,6 +15,7 @@ import tempfile
 TYPE_MAPPINGS = {"numeric": "bytes", "text": "string", "boolean": "bool"}
 
 BLOCK_COLUMN = "_block_number"
+BLOCK_COLUMN_TYPE = pyarrow.uint32()
 
 
 def get_select_all_exclusive(
@@ -103,7 +104,7 @@ def get_subgraph_block_range(subgraph, database_string):
 
 
 def convert_columns(df, database_types, table_config):
-    update_types = {}
+    update_types = {BLOCK_COLUMN: BLOCK_COLUMN_TYPE}
     new_columns = {}
     for column, mappings in table_config.get("column_mappings", {}).items():
         for new_column_name, new_column_config in mappings.items():
@@ -140,6 +141,7 @@ def convert_columns(df, database_types, table_config):
     table = pyarrow.Table.from_pandas(df, preserve_index=False)
     schema = table.schema
     types = {
+        "uint32": pyarrow.uint32(),
         "uint64": pyarrow.uint64(),
         "bytes": pyarrow.binary(),
         "bool": pyarrow.bool_(),

--- a/tests/resources/example_db.sql
+++ b/tests/resources/example_db.sql
@@ -42,6 +42,25 @@ CREATE TABLE sgd1.sample_table (
     to_address text
 );
 
+CREATE TABLE sgd1.prepaid_card_ask_sample (
+  block_range int4range NOT NULL,
+  vid bigint NOT NULL,
+  ask_price numeric NOT NULL,
+  issuing_token text NOT NULL,
+  sku text NOT NULL,
+  id text NOT NULL
+);
+
+ALTER TABLE sgd1.prepaid_card_ask_sample ADD CONSTRAINT prepaid_card_ask_pkey PRIMARY KEY (vid);
+insert into "sgd1"."prepaid_card_ask_sample" ("ask_price", "block_range", "id", "issuing_token", "sku", "vid") values ('10000000000000000000', '[18460372,)', '0x01974608d9b1b9b7dc822715f7167437d3fa938b579ccc2f60b135d01d35f505', '0x26F2319Fbb44772e0ED58fB7c99cf8da59e2b5BE', '0x01974608d9b1b9b7dc822715f7167437d3fa938b579ccc2f60b135d01d35f505', '1');
+insert into "sgd1"."prepaid_card_ask_sample" ("ask_price", "block_range", "id", "issuing_token", "sku", "vid") values ('10000000000000000000', '[18887449,)', '0x2a635070ac5332e28e657bfd717363165dba145ddc6d5eca39b12faacb861149', '0x26F2319Fbb44772e0ED58fB7c99cf8da59e2b5BE', '0x2a635070ac5332e28e657bfd717363165dba145ddc6d5eca39b12faacb861149', '2');
+insert into "sgd1"."prepaid_card_ask_sample" ("ask_price", "block_range", "id", "issuing_token", "sku", "vid") values ('25000000000000000000', '[18888080,)', '0xe48b3fa88fea42a5720fdeeaabf99065c666be73ff9b99977b403521deb47eee', '0x26F2319Fbb44772e0ED58fB7c99cf8da59e2b5BE', '0xe48b3fa88fea42a5720fdeeaabf99065c666be73ff9b99977b403521deb47eee', '3');
+insert into "sgd1"."prepaid_card_ask_sample" ("ask_price", "block_range", "id", "issuing_token", "sku", "vid") values ('75000000000000000000', '[18888096,)', '0x72f15a7e3b61878976a917626f019b4488ca290f868b37a321e84fade75735d5', '0x26F2319Fbb44772e0ED58fB7c99cf8da59e2b5BE', '0x72f15a7e3b61878976a917626f019b4488ca290f868b37a321e84fade75735d5', '4');
+insert into "sgd1"."prepaid_card_ask_sample" ("ask_price", "block_range", "id", "issuing_token", "sku", "vid") values ('150000000000000000000', '[18888106,)', '0xc1f1cb58f15cf68dd8a11b3e6189be3a79bbf10d4c826f9323c302b9a1a8236c', '0x26F2319Fbb44772e0ED58fB7c99cf8da59e2b5BE', '0xc1f1cb58f15cf68dd8a11b3e6189be3a79bbf10d4c826f9323c302b9a1a8236c', '5');
+insert into "sgd1"."prepaid_card_ask_sample" ("ask_price", "block_range", "id", "issuing_token", "sku", "vid") values ('250000000000000000000', '[18888119,)', '0x73ea1c11dbd7fd47fd0eb753013173dd5cbe04f4d11de3b96d471ae7a6dc7e22', '0x26F2319Fbb44772e0ED58fB7c99cf8da59e2b5BE', '0x73ea1c11dbd7fd47fd0eb753013173dd5cbe04f4d11de3b96d471ae7a6dc7e22', '6');
+;
+
+
 CREATE TABLE subgraphs.subgraph_deployment (
   firehose_cursor text NULL,
   id integer NOT NULL,

--- a/tests/test_get_column_info.py
+++ b/tests/test_get_column_info.py
@@ -50,3 +50,39 @@ def test_get_column_types(db_conn, table_schema_name, valid_table_name):
         "from_address": "text",
         "to_address": "text",
     }
+
+
+def test_blockrange_returns_uint32(db_conn):
+
+    db_columns = get_column_types(db_conn, "sgd1", "prepaid_card_ask_sample")
+    df = pandas.read_sql(
+        sql=get_select_all_exclusive(
+            db_conn,
+            "sgd1",
+            "prepaid_card_ask_sample",
+            start_partition=18460372,
+            end_partition=18888120,
+        ),
+        con=db_conn,
+        coerce_float=False,
+    )
+    typed_df = convert_columns(df, db_columns, {})
+    assert typed_df.schema.field_by_name("_block_number").type == pyarrow.uint32()
+
+
+def test_blockrange_returns_uint32_when_empty(db_conn):
+
+    db_columns = get_column_types(db_conn, "sgd1", "prepaid_card_ask_sample")
+    df = pandas.read_sql(
+        sql=get_select_all_exclusive(
+            db_conn,
+            "sgd1",
+            "prepaid_card_ask_sample",
+            start_partition=19000000,
+            end_partition=19100000,
+        ),
+        con=db_conn,
+        coerce_float=False,
+    )
+    typed_df = convert_columns(df, db_columns, {})
+    assert typed_df.schema.field_by_name("_block_number").type == pyarrow.uint32()


### PR DESCRIPTION
The generated _block_number column is inconsistently set in the
output files, depending on whether there is any data or not.

This breaks anything that tries to read across multiple files
when one of them is empty (possibly more cases).

We force uint32 instead.